### PR TITLE
Fix missing parenthesis opener key causing error

### DIFF
--- a/PSR2R/Sniffs/ControlStructures/UnneededElseSniff.php
+++ b/PSR2R/Sniffs/ControlStructures/UnneededElseSniff.php
@@ -31,6 +31,10 @@ class UnneededElseSniff extends AbstractSniff {
 		$scopeStartIndex = $tokens[$prevScopeEndIndex]['scope_opener'];
 
 		$prevParenthesisEndIndex = $phpcsFile->findPrevious(T_WHITESPACE, $scopeStartIndex - 1, null, true);
+		if (!$prevParenthesisEndIndex || !array_key_exists('parenthesis_opener', $tokens[$prevParenthesisEndIndex])) {
+			return;
+		}
+
 		$parenthesisStartIndex = $tokens[$prevParenthesisEndIndex]['parenthesis_opener'];
 
 		$prevConditionIndex = $phpcsFile->findPrevious(T_WHITESPACE, $parenthesisStartIndex - 1, null, true);


### PR DESCRIPTION
On a very large project with lots of errors files would keep getting fatal errors when the array key 'parenthesis_opener' did not exist.

This adds a sanity check to verify that $prevParenthesisEndIndex exists and the 'parenthesis_opener' key exists.