### PR TITLE
DocBlockAlignmentSniff.php: add enum support

### DIFF
--- a/PSR2R/Sniffs/WhiteSpace/DocBlockAlignmentSniff.php
+++ b/PSR2R/Sniffs/WhiteSpace/DocBlockAlignmentSniff.php
@@ -45,12 +45,14 @@ class DocBlockAlignmentSniff extends AbstractSniff {
 		$tokens = $phpcsFile->getTokens();
 		$leftWall = [
 			T_CLASS,
+			T_ENUM,
 			T_NAMESPACE,
 			T_INTERFACE,
 			T_TRAIT,
 			T_USE,
 		];
 		$oneIndentation = [
+			T_ENUM_CASE,
 			T_FUNCTION,
 			T_VARIABLE,
 			T_CONST,

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
 	"require": {
 		"php": ">=7.3",
 		"spryker/code-sniffer": "^0.17.1",
-		"slevomat/coding-standard": "^7.0.1"
+		"slevomat/coding-standard": "^7.0.1",
+		"squizlabs/php_codesniffer": "^3.7.0"
 	},
 	"require-dev": {
 		"phpstan/phpstan": "^1.0.0"


### PR DESCRIPTION
This requires `squizlabs/php_codesniffer` master branch (forthcoming version 3.7.0), which adds tokenizer support for `T_ENUM` and `T_ENUM_CASE`. ~~You may want to consider waiting to merge this until 3.7.0 is released.~~ Version 3.7.0 was released on 2022-06-12!