### PR TITLE
Improve trailing comma consistency

### DIFF
--- a/PSR2R/Sniffs/ControlStructures/ConditionalExpressionOrderSniff.php
+++ b/PSR2R/Sniffs/ControlStructures/ConditionalExpressionOrderSniff.php
@@ -167,7 +167,8 @@ class ConditionalExpressionOrderSniff extends AbstractSniff {
 		$leftIndexStart,
 		$leftIndexEnd,
 		$rightIndexStart,
-		$rightIndexEnd) {
+		$rightIndexEnd,
+	) {
 		$tokens = $phpCsFile->getTokens();
 
 		$token = $tokens[$index];

--- a/PSR2R/ruleset.xml
+++ b/PSR2R/ruleset.xml
@@ -43,9 +43,19 @@
 
 	<rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration"/>
 	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
-	<rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration"/>
-	<rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse"/>
 	<rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall">
+		<properties>
+			<property name="onlySingleLine" type="boolean" value="true"/>
+		</properties>
+	</rule>
+	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
+	<rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration">
+		<properties>
+			<property name="onlySingleLine" type="boolean" value="true"/>
+		</properties>
+	</rule>
+	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>
+	<rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse">
 		<properties>
 			<property name="onlySingleLine" type="boolean" value="true"/>
 		</properties>

--- a/docs/sniffs.md
+++ b/docs/sniffs.md
@@ -127,9 +127,9 @@ SlevomatCodingStandard (42 sniffs)
 - SlevomatCodingStandard.ControlStructures.RequireShortTernaryOperator
 - SlevomatCodingStandard.Exceptions.DeadCatch
 - SlevomatCodingStandard.Functions.ArrowFunctionDeclaration
-- SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall
-- SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse
-- SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration
+- SlevomatCodingStandard.Functions.RequireTrailingCommaInCall
+- SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse
+- SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration
 - SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses
 - SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
 - SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile


### PR DESCRIPTION
The current ruleset requires a trailing comma in multi-line calls, and disallows trailing commas in single-line calls. However, it disallows trailing commas in all declarations and closures (new in v1.5.0).

For consistency, this changes the trailing comma rules for declarations and closures to match calls (no in single-line, yes in multi-line).

----------

I wasn't sure how to best represent this in the `sniffs.md` page, since it might be confusing to see that we are using both "Disallow" and "Require" for the same criteria, so I switched them to "Require" since that's likely to be the most illuminating. I would have added them both with parenthetical comments to distinguish between single- and multi-line use, but wasn't sure if you'd want that.

No offense will be taken if you prefer the new behavior in v1.5.0 and decide to close this PR. Either way, thanks for your consideration!