### PR TITLE
Allow @link and @see as inline doc comment markers

### DIFF
--- a/PSR2R/Sniffs/Commenting/DocCommentSniff.php
+++ b/PSR2R/Sniffs/Commenting/DocCommentSniff.php
@@ -46,8 +46,8 @@ class DocCommentSniff extends AbstractSniff {
 	public function process(File $phpcsFile, int $stackPtr): void {
 		$tokens = $phpcsFile->getTokens();
 
-		// Skip for PhpStorm markers which must remain as inline comments
-		if ($this->isPhpStormMarker($phpcsFile, $stackPtr)) {
+		// Skip for inline comment markers which must remain as inline comments
+		if ($this->isInlineCommentMarker($phpcsFile, $stackPtr)) {
 			return;
 		}
 

--- a/PSR2R/Sniffs/WhiteSpace/DocBlockAlignmentSniff.php
+++ b/PSR2R/Sniffs/WhiteSpace/DocBlockAlignmentSniff.php
@@ -42,6 +42,11 @@ class DocBlockAlignmentSniff extends AbstractSniff {
 			return;
 		}
 
+		// Skip for inline comment markers which must remain as inline comments
+		if ($this->isInlineCommentMarker($phpcsFile, $stackPtr)) {
+			return;
+		}
+
 		$tokens = $phpcsFile->getTokens();
 		$leftWall = [
 			T_CLASS,

--- a/PSR2R/Tools/AbstractSniff.php
+++ b/PSR2R/Tools/AbstractSniff.php
@@ -10,7 +10,7 @@ abstract class AbstractSniff implements Sniff {
 	/**
 	 * @var array<string> These markers must remain as inline comments
 	 */
-	protected static array $phpStormMarkers = ['@noinspection'];
+	protected static array $inlineCommentMarkers = ['@noinspection', '@link', '@see'];
 
 	/**
 	 * Checks if the given token is of this token code/type.
@@ -369,7 +369,7 @@ abstract class AbstractSniff implements Sniff {
 	 *
 	 * @return bool
 	 */
-	protected function isPhpStormMarker(File $phpcsFile, int $stackPtr): bool {
+	protected function isInlineCommentMarker(File $phpcsFile, int $stackPtr): bool {
 		$tokens = $phpcsFile->getTokens();
 		$line = $tokens[$stackPtr]['line'];
 		if ($tokens[$stackPtr]['type'] !== 'T_DOC_COMMENT_OPEN_TAG') {
@@ -379,7 +379,7 @@ abstract class AbstractSniff implements Sniff {
 		if ($line !== $tokens[$end]['line']) {
 			return false; // Not an inline comment
 		}
-		foreach (static::$phpStormMarkers as $marker) {
+		foreach (static::$inlineCommentMarkers as $marker) {
 			if ($phpcsFile->findNext(T_DOC_COMMENT_TAG, $stackPtr + 1, $end, false, $marker) !== false) {
 				return true;
 			}


### PR DESCRIPTION
## Summary
- Renamed `$phpStormMarkers` to `$inlineCommentMarkers` for clarity
- Added `@link` and `@see` to allowed inline comment markers
- Updated `DocCommentSniff` to use renamed method
- Updated `DocBlockAlignmentSniff` to skip inline comment markers

This allows inline doc comments like:
```php
/** @link validateUniqueLinks() */
'rule' => 'validateUniqueLinks',
```

Without triggering:
- "The open comment tag must be the only content on the line" (`DocCommentSniff`)
- "Expected docblock to be aligned with code" (`DocBlockAlignmentSniff`)