### PR TITLE
Fix docblock alignment fixer loop

### DIFF
--- a/PSR2R/Sniffs/WhiteSpace/DocBlockAlignmentSniff.php
+++ b/PSR2R/Sniffs/WhiteSpace/DocBlockAlignmentSniff.php
@@ -110,7 +110,7 @@ class DocBlockAlignmentSniff extends AbstractSniff {
 
 			$phpcsFile->fixer->beginChangeset();
 
-			$this->outdent($phpcsFile, $prevIndex);
+			$this->outdentLeadingIndent($phpcsFile, $prevIndex);
 
 			for ($i = $stackPtr; $i <= $docBlockEndIndex; $i++) {
 				if (!$this->isGivenKind(T_DOC_COMMENT_WHITESPACE, $tokens[$i]) ||
@@ -118,7 +118,7 @@ class DocBlockAlignmentSniff extends AbstractSniff {
 				) {
 					continue;
 				}
-				$this->outdent($phpcsFile, $i);
+				$this->outdentLeadingIndent($phpcsFile, $i);
 			}
 			$phpcsFile->fixer->endChangeset();
 
@@ -138,7 +138,7 @@ class DocBlockAlignmentSniff extends AbstractSniff {
 		if ($diff < 0 && $tokens[$prevIndex]['line'] !== $tokens[$stackPtr]['line']) {
 			$phpcsFile->fixer->addContentBefore($stackPtr, str_repeat("\t", -$diff));
 		} else {
-			$this->outdent($phpcsFile, $prevIndex);
+			$this->outdentLeadingIndent($phpcsFile, $prevIndex);
 		}
 
 		for ($i = $stackPtr; $i <= $docBlockEndIndex; $i++) {
@@ -148,9 +148,9 @@ class DocBlockAlignmentSniff extends AbstractSniff {
 				continue;
 			}
 			if ($diff < 0) {
-				$this->indent($phpcsFile, $i, -$diff);
+				$this->indentWithTabs($phpcsFile, $i, -$diff);
 			} else {
-				$this->outdent($phpcsFile, $i, $diff);
+				$this->outdentLeadingIndent($phpcsFile, $i, $diff);
 			}
 		}
 		$phpcsFile->fixer->endChangeset();
@@ -171,6 +171,37 @@ class DocBlockAlignmentSniff extends AbstractSniff {
 		}
 
 		return $phpcsFile->findNext(T_WHITESPACE, $firstIndex, $index, true);
+	}
+
+	/**
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
+	 * @param int $index
+	 * @param int $count
+	 *
+	 * @return void
+	 */
+	protected function indentWithTabs(File $phpcsFile, int $index, int $count = 1): void {
+		$tokens = $phpcsFile->getTokens();
+
+		$content = str_repeat("\t", $count) . $tokens[$index]['content'];
+		$phpcsFile->fixer->replaceToken($index, $content);
+	}
+
+	/**
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
+	 * @param int $index
+	 * @param int $count
+	 *
+	 * @return void
+	 */
+	protected function outdentLeadingIndent(File $phpcsFile, int $index, int $count = 1): void {
+		$tokens = $phpcsFile->getTokens();
+
+		$content = $tokens[$index]['content'];
+		for ($i = 0; $i < $count; $i++) {
+			$content = preg_replace('/^(?:\t| {4})/', '', $content, 1) ?? $content;
+		}
+		$phpcsFile->fixer->replaceToken($index, $content);
 	}
 
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,6 @@
 
 	<php>
 		<ini name="memory_limit" value="-1"/>
-		<ini name="apc.enable_cli" value="1"/>
 	</php>
 
 	<testsuites>

--- a/tests/PSR2R/Sniffs/WhiteSpace/DocBlockIndentConflictTest.php
+++ b/tests/PSR2R/Sniffs/WhiteSpace/DocBlockIndentConflictTest.php
@@ -39,4 +39,38 @@ class DocBlockIndentConflictTest extends TestCase {
 		$this->runFullFixer($pathBefore, $pathAfter, null, null, true);
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testDocBlockAlignmentDoesNotLoopWithTabIndentFixer(): void {
+		$pathBefore = $this->testFilePath() . 'DocBlockAlignmentLoop/before.php';
+		$pathAfter = $this->testFilePath() . 'DocBlockAlignmentLoop/after.php';
+
+		$tmpFile = tempnam(sys_get_temp_dir(), 'psr2r-docblock-loop-');
+		$this->assertIsString($tmpFile);
+		unlink($tmpFile);
+		$tmpFile .= '.php';
+		$this->assertTrue(copy($pathBefore, $tmpFile));
+
+		$root = dirname(__DIR__, 4);
+		$command = PHP_BINARY . ' ' . escapeshellarg($root . '/vendor/bin/phpcbf') .
+			' --standard=' . escapeshellarg($root . '/PSR2R/ruleset.xml') .
+			' --sniffs=PSR2R.WhiteSpace.DocBlockAlignment,PSR2R.WhiteSpace.TabIndent' .
+			' ' . escapeshellarg($tmpFile);
+
+		try {
+			$output = [];
+			$exitCode = 0;
+			exec($command . ' 2>&1', $output, $exitCode);
+
+			$this->assertSame(0, $exitCode, implode(PHP_EOL, $output));
+			$this->assertStringNotContainsString('FAILED TO FIX', implode(PHP_EOL, $output));
+			$this->assertSame(file_get_contents($pathAfter), file_get_contents($tmpFile));
+		} finally {
+			if (file_exists($tmpFile)) {
+				unlink($tmpFile);
+			}
+		}
+	}
+
 }

--- a/tests/_data/DocBlockAlignmentLoop/after.php
+++ b/tests/_data/DocBlockAlignmentLoop/after.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+class DocBlockLoop {
+
+	public function checkEmails(array $users): void {
+		$result = [];
+
+		/** @var \App\User $user */
+		foreach ($users as $user) {
+			$result[] = $user;
+		}
+	}
+
+}

--- a/tests/_data/DocBlockAlignmentLoop/before.php
+++ b/tests/_data/DocBlockAlignmentLoop/before.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+class DocBlockLoop {
+
+	public function checkEmails(array $users): void {
+		$result = [];
+
+			/** @var \App\User $user */
+		foreach ($users as $user) {
+			$result[] = $user;
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary
- keep DocBlockAlignmentSniff indentation fixes tab-based instead of inferring indentation from docblock whitespace
- add a PHPCBF regression test for the DocBlockAlignment + TabIndent fixer loop
- remove stale apc.enable_cli PHPUnit ini setting so the suite exits successfully on current PHPUnit/PHP setups

## Reproducer
Before this change, the new DocBlockAlignmentLoop fixture makes PHPCBF alternate between:
- PSR2R.WhiteSpace.DocBlockAlignment converting the docblock opening line to spaces
- PSR2R.WhiteSpace.TabIndent converting it back to tabs

That reaches PHPCBF's max loop limit and reports FAILED TO FIX.

## Checks
- composer test
- composer cs-check
- composer stan