### PR TITLE
Skip final classes in static-over-self sniff

### DIFF
--- a/PSR2R/Sniffs/PHP/PreferStaticOverSelfSniff.php
+++ b/PSR2R/Sniffs/PHP/PreferStaticOverSelfSniff.php
@@ -34,6 +34,9 @@ class PreferStaticOverSelfSniff extends AbstractSniff {
 		if ($tokens[$index]['level'] < 2) {
 			return;
 		}
+		if ($this->isInFinalClass($phpcsFile, $stackPtr)) {
+			return;
+		}
 
 		$fix = $phpcsFile->addFixableError('Please use static:: instead of self::', $stackPtr, 'StaticVsSelf');
 		if (!$fix) {
@@ -41,6 +44,23 @@ class PreferStaticOverSelfSniff extends AbstractSniff {
 		}
 
 		$phpcsFile->fixer->replaceToken($index, 'static');
+	}
+
+	/**
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
+	 * @param int $stackPtr
+	 * @return bool
+	 */
+	protected function isInFinalClass(File $phpcsFile, int $stackPtr): bool {
+		$tokens = $phpcsFile->getTokens();
+		$classPtr = $phpcsFile->findPrevious(T_CLASS, $stackPtr - 1);
+		if ($classPtr === false || empty($tokens[$classPtr]['scope_closer']) || $tokens[$classPtr]['scope_closer'] < $stackPtr) {
+			return false;
+		}
+
+		$previous = $phpcsFile->findPrevious(Tokens::$emptyTokens, $classPtr - 1, null, true);
+
+		return $previous !== false && $tokens[$previous]['code'] === T_FINAL;
 	}
 
 }

--- a/tests/PSR2R/Sniffs/PHP/PreferStaticOverSelfSniffTest.php
+++ b/tests/PSR2R/Sniffs/PHP/PreferStaticOverSelfSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PSR2R\Test\PSR2R\Sniffs\PHP;
+
+use PSR2R\Sniffs\PHP\PreferStaticOverSelfSniff;
+use PSR2R\Test\TestCase;
+
+class PreferStaticOverSelfSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testStaticOverSelfSniffer(): void
+    {
+        $this->assertSnifferFindsErrors(new PreferStaticOverSelfSniff(), 1);
+    }
+
+    /**
+     * @return void
+     */
+    public function testStaticOverSelfFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new PreferStaticOverSelfSniff());
+    }
+}

--- a/tests/_data/PreferStaticOverSelf/after.php
+++ b/tests/_data/PreferStaticOverSelf/after.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace PSR2R;
+
+class FixMe {
+
+	public const VALUE = 'value';
+
+	public function value(): string {
+		return static::VALUE;
+	}
+
+}
+
+final class KeepMe {
+
+	public const VALUE = 'value';
+
+	public function value(): string {
+		return self::VALUE;
+	}
+
+}

--- a/tests/_data/PreferStaticOverSelf/before.php
+++ b/tests/_data/PreferStaticOverSelf/before.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace PSR2R;
+
+class FixMe {
+
+	public const VALUE = 'value';
+
+	public function value(): string {
+		return self::VALUE;
+	}
+
+}
+
+final class KeepMe {
+
+	public const VALUE = 'value';
+
+	public function value(): string {
+		return self::VALUE;
+	}
+
+}


### PR DESCRIPTION
The `PSR2R.PHP.PreferStaticOverSelf` sniff currently conflicts with `Universal.CodeAnalysis.StaticInFinalClass`: it fixes `self::` to `static::` even when the containing class is final, and the final-class sniff then correctly changes it back.

This makes `PreferStaticOverSelf` skip `self::` usages inside final classes, where late static binding cannot provide extension behavior. A regression fixture keeps non-final classes fixable while preserving `self::` in final classes.

Verified locally:
- composer cs-fix
- composer cs-check
- composer stan
- vendor/bin/phpunit --filter PreferStaticOverSelfSniffTest
- composer test