### PR TITLE
Fix DeprecatedFunctions override disabling the sniff

### DIFF
--- a/PSR2R/ruleset.xml
+++ b/PSR2R/ruleset.xml
@@ -256,18 +256,31 @@
 
 	<rule ref="Squiz.Operators.ValidLogicalOperators"/>
 
-	<rule ref="Generic.PHP.DeprecatedFunctions">
+	<!--
+		Do not set the `forbiddenFunctions` property here. The sniff populates it in its
+		constructor from the Reflection API (every internal function marked deprecated for
+		the running PHP version). Setting the property replaces that list instead of adding
+		to it, which silently disables the sniff.
+	-->
+	<rule ref="Generic.PHP.DeprecatedFunctions"/>
+
+	<rule ref="Squiz.PHP.Eval"/>
+	<!--
+		Setting the property replaces the sniff's defaults, so `sizeof` and `delete` have to be
+		repeated here. `create_function` and `each` live here rather than on
+		Generic.PHP.DeprecatedFunctions because that sniff builds its list from the running
+		PHP version, where both are long gone.
+	-->
+	<rule ref="Generic.PHP.ForbiddenFunctions">
 		<properties>
 			<property name="forbiddenFunctions" type="array">
+				<element key="sizeof" value="count"/>
 				<element key="delete" value="unset"/>
 				<element key="create_function" value="null"/>
 				<element key="each" value="null"/>
 			</property>
 		</properties>
 	</rule>
-
-	<rule ref="Squiz.PHP.Eval"/>
-	<rule ref="Generic.PHP.ForbiddenFunctions"/>
 	<rule ref="Squiz.PHP.NonExecutableCode"/>
 	<rule ref="Generic.PHP.NoSilencedErrors"/>
 	<rule ref="Generic.PHP.LowerCaseConstant"/>


### PR DESCRIPTION
`Generic.PHP.DeprecatedFunctions` has no static list. Its constructor walks `get_defined_functions()` and asks `ReflectionFunction::isDeprecated()`, so it tracks whatever the running PHP marks deprecated - automatically, per version. The ruleset set `forbiddenFunctions` to a three-entry array, and a ruleset property assignment *replaces* the value rather than extending it. The reflection-built list was discarded on every run.

Before:

```
$ phpcs --standard=Generic --sniffs=Generic.PHP.DeprecatedFunctions dep.php
 2 | ERROR | Function utf8_encode() has been deprecated

$ phpcs --standard=PSR2R --sniffs=Generic.PHP.DeprecatedFunctions dep.php
(nothing)
```

The three entries were also a poor trade: `each` and `create_function` were removed in PHP 8.0, so reflection cannot see them either way, and `delete` was never a PHP function. They move to `Generic.PHP.ForbiddenFunctions`, whose list *is* a plain property and is the right home for removed-in-8.0 names. Its two defaults are repeated there because that override replaces too.

After, all five report:

```
 2 | ERROR | The use of function create_function() is forbidden
 3 | ERROR | The use of function each() is forbidden
 4 | ERROR | The use of function delete() is forbidden; use unset() instead
 5 | ERROR | The use of function sizeof() is forbidden; use count() instead
 6 | ERROR | Function utf8_encode() has been deprecated
```

Same defect and same fix as php-collective/code-sniffer#71, found while sweeping both standards.
