### PR TITLE
Allow PHPUnit 13 and migrate the test configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor/
 /phpunit.phar
+/.phpunit.cache
 /.phpunit.result.cache
 /composer.phar
 /composer.lock

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"squizlabs/php_codesniffer": "^4.0.2"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^10.3 || ^11.5 || ^12.0",
+		"phpunit/phpunit": "^10.3 || ^11.5 || ^12.0 || ^13.0",
 		"phpstan/phpstan": "^2.1.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0"
 	},

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-	<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.2/phpunit.xsd" cacheDirectory=".phpunit.cache">
 	<php>
 		<ini name="memory_limit" value="-1"/>
 	</php>
@@ -11,9 +10,9 @@
 		</testsuite>
 	</testsuites>
 
-	<coverage processUncoveredFiles="true">
+	<source>
 		<include>
 			<directory>PSR2R/</directory>
 		</include>
-	</coverage>
+	</source>
 </phpunit>


### PR DESCRIPTION
Two bits of test-tooling maintenance.

### PHPUnit 13

`require-dev` capped at `^12.0`, so no CI job ran the current major. PHPUnit 13 requires PHP 8.4, so Composer resolves 11 on the 8.1 job and 13 on the 8.5 one - the supported range stays exercised rather than pinned to one major.

### Configuration schema

Every run reported:

```
1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!
```

`phpunit.xml.dist` still declared the 9.3 schema. Migrated: `coverage` becomes `source`, `cacheDirectory` is declared, and the stray indentation on the opening `<phpunit>` tag is gone. Tab indentation and the blank-line grouping are preserved - the migration tool rewrites both.

Verified against 11.5.56, 12.5.19 and 13.2.6: 19 tests pass on each, and none of them reports a schema deprecation.

`.phpunit.cache` is added to `.gitignore`; only the older `.phpunit.result.cache` file was listed.
